### PR TITLE
Mask out-of-bounds centroids

### DIFF
--- a/fastkmeans/triton_kernels.py
+++ b/fastkmeans/triton_kernels.py
@@ -93,6 +93,9 @@ def _kmeans_kernel(
     # finish distance formula
     dist = tl.fma(dot_acc, -2.0, x_n[:, None] + c_n[None, :])  # [BM, BN]
 
+    # set large value for invalid distances
+    dist = tl.where(col_mask[None, :], dist, 1e38)
+
     # local arg‑min (inside this tile)
     tile_min, tile_idx = tl.min(dist, axis=1, return_indices=True)
 


### PR DESCRIPTION
Fixes a bug on the Titron kernel for inputs requiring padding.

Padded centroids `(cols ≥ C)` were loaded as zeros and could win the per-tile min, producing `best_ids ≥ k`, triggering an index error. Now out-of-bounds centroids are set to 1e38 which should prevent them winning the per-tile min.